### PR TITLE
Dockerfile: disable root login

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,7 @@ RUN apk add --no-cache gettext
 
 COPY auth.conf auth.htpasswd launch.sh ./
 
+# make sure root login is disabled
+RUN sed -i -e 's/^root::/root:!:/' /etc/shadow
+
 CMD ["./launch.sh"]


### PR DESCRIPTION
Disable root login
Closes beevelop/docker-nginx-basic-auth#21